### PR TITLE
Add initial CI workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,37 @@
+# This workflow will install the tool with dependencies and then run the examples as tests with output to the terminal
+# It will run jobs in the two latest versions of Ubuntu with different python versions
+
+name: Python package
+
+on: # run this on every push and pull request on all branches
+  push:
+    branches:
+      - '*'  
+  pull_request:
+    branches:
+      - '*'  
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true # cancel all jobs if one job in the matrix fails
+      matrix: # run a job on each combintation of os and python versions
+        os: [ubuntu-24.04, ubuntu-22.04]
+        # use the available python versions for os versions (nothing older than v3.11 is available for both) : https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+        python-version: ["3.11.0", "3.12.0", "3.13.0"]
+        
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }} in ${{ matrix.os }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install tool with dependencies
+      run: |
+        sudo apt-get install -y libegl-dev # install dependency for PyQt6
+        pip install .
+    - name: Test 
+      run: | # run both examples with all output printed to the terminal
+       python scripts/preview_scenario.py -m abstract -s test_scenario_terminal.json
+       python scripts/preview_scenario.py -m iq -s test_scenario_terminal.json

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The RFRL Gym is intended as a training and research environment for wireless com
 
 _Note: Pardon our mess as this project is under active development. Please let us know of any feature requests or bugs to be squashed!_
 
+![python package workflow](https://github.com/ljmciver/rfrl-gym/actions/workflows/python-package.yml/badge.svg)
+
 ## To install the codebase:
 
 ### Linux (verified in Ubuntu)

--- a/rfrl_gym/envs/rfrl_gym_abstract_env.py
+++ b/rfrl_gym/envs/rfrl_gym_abstract_env.py
@@ -140,8 +140,10 @@ class RFRLGymAbstractEnv(gym.Env):
                 time.sleep(self.next_frame_time - time.time())
         return
 
-    def close(self):        
-        input('Press Enter to end the simulation...')
+    def close(self):
+        # request the user close the simulation
+        if self.render_mode == 'pyqt':
+            input('Press Enter to end the simulation...')
         return
 
     def __validate_scenario_metadata(self):

--- a/rfrl_gym/envs/rfrl_gym_iq_env.py
+++ b/rfrl_gym/envs/rfrl_gym_iq_env.py
@@ -159,7 +159,9 @@ class RFRLGymIQEnv(gym.Env):
         return
 
     def close(self):        
-        input('Press Enter to end the simulation...')
+        # request the user close the simulation
+        if self.render_mode == 'pyqt':
+            input('Press Enter to end the simulation...')
         return
 
     def __validate_scenario_metadata(self):

--- a/scenarios/test_scenario_terminal.json
+++ b/scenarios/test_scenario_terminal.json
@@ -1,0 +1,91 @@
+{
+    "environment": 
+    {
+	    "num_channels": 10,
+	    "max_steps": 10,
+	    "observation_mode": "classify",
+	    "reward_mode": "jam",
+        "target_entity": "fixed_hop_freq_1",
+        "detector": 
+        {
+            "energy_detector":
+            {
+                "type": "EnergyDetector"
+            }
+        }
+    },
+    "entities": 
+    {
+        "constant_freq_1": 
+        {
+            "type": "ConstantFreq",
+            "channels": [0],
+            "onoff": [1,1,0],
+            "modem_params":
+            {
+                "type": "qam",
+                "order": 16,
+                "filter": "RRC",
+                "center_frequency": [-0.1,0.1],
+                "bandwidth": 0.25,
+                "start": 0.25,
+                "duration": 0.25
+            }
+        },
+        "constant_freq_2":
+        {
+            "type": "ConstantFreq",
+            "channels": [9],
+            "onoff": [1,1,0],
+            "modem_params":
+            {
+                "type": "psk",
+                "order": 4,
+                "filter": "RRC",
+                "center_frequency": [-0.1,0.1],
+                "bandwidth": 0.5,
+                "start": 0.5,
+                "duration": 0.25
+            }
+        },
+        "fixed_hop_freq_1":
+        {
+            "type": "FixedHopFreq",
+            "channels": [1,2,3,4,5,6,7,8],
+            "onoff": [1,1,0],
+            "rand_hop": 0,
+            "modem_params":
+            {
+                "type": "n_fmcw",
+                "center_frequency": [0.0,0.0],
+                "bandwidth": 1.0,
+                "start": 0.0,
+                "duration": 1.0
+            }
+        },
+        "fixed_hop_freq_2":
+        {
+            "type": "FixedHopFreq",
+            "channels": [3,6,8,1,4,2,5,7],
+            "onoff": [1,1,0],
+            "rand_hop": 0,
+            "modem_params":
+            {
+                "type": "ask",
+                "order": 4,
+                "filter": "RRC",
+                "center_frequency": [0.0,0.0],
+                "bandwidth": 0.5,
+                "start": 0.0,
+                "duration": 1.0
+            }
+        }        
+    },
+    "render":
+    {
+        "render_mode": "terminal",
+        "render_fps": 100,
+        "render_history": 20,
+        "render_background": "black"
+    }
+}


### PR DESCRIPTION
This adds a workflow through GitHub actions which will be run with any push or pull request on any branch.

* The workflow runs the two examples in two versions of Ubuntu and all Python versions available in those environments. 
* The gym environments are modified to remove the user required input to end the simulation in all but the pyqt mode. This allows for testing in the terminal mode.
* A new test scenario json file is added which is the same as the example json except it runs in terminal mode and the total number of steps is reduced from 100 to 10 to reduce the overall test runtime.
* A badge is added to the README.md to display the most recent test results (pass/fail). The code works in the fork but will need to be changed slightly to work in this repository.

This line in the README.md will need to change from this 
```
![python package workflow](https://github.com/ljmciver/rfrl-gym/actions/workflows/python-package.yml/badge.svg)
```
to this line (with "vtnsi" replacing "ljmciver")
```
![python package workflow](https://github.com/vtnsi/rfrl-gym/actions/workflows/python-package.yml/badge.svg)
```
